### PR TITLE
deps: updates wazero to 1.0.0-pre.3

### DIFF
--- a/pi-zero-ssr/handler/go.mod
+++ b/pi-zero-ssr/handler/go.mod
@@ -2,4 +2,4 @@ module ssr-handler
 
 go 1.17
 
-require github.com/tetratelabs/wazero v1.0.0-pre.1
+require github.com/tetratelabs/wazero v1.0.0-pre.3

--- a/pi-zero-ssr/handler/go.sum
+++ b/pi-zero-ssr/handler/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.1 h1:bUZ4vf21c36RmgA3enNOlLgPElEVDYoRJJ9+McRGF6Q=
-github.com/tetratelabs/wazero v1.0.0-pre.1/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
+github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=

--- a/pi-zero-ssr/handler/main.go
+++ b/pi-zero-ssr/handler/main.go
@@ -45,7 +45,7 @@ func main() {
   }
 
   // Compile module for run boost!
-  compiled, err := r.CompileModule(ctx, wasm, wazero.NewCompileConfig())
+  compiled, err := r.CompileModule(ctx, wasm)
   if err != nil {
     log.Panicln(err)
   }


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3). This is the last release that will build with Go 1.17.

Notably, this improves performance and changes host function syntax.