### PR TITLE
deps: updates wazero to 1.0.0-pre.4

### DIFF
--- a/pi-zero-ssr/handler/go.mod
+++ b/pi-zero-ssr/handler/go.mod
@@ -2,4 +2,4 @@ module ssr-handler
 
 go 1.17
 
-require github.com/tetratelabs/wazero v1.0.0-pre.3
+require github.com/tetratelabs/wazero v1.0.0-pre.4

--- a/pi-zero-ssr/handler/go.sum
+++ b/pi-zero-ssr/handler/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
-github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.4](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.4).

Notably, v1.0.0-pre.4:
* improves module initialization speed
* supports listeners in the compiler engine
* supports WASI `fd_pread`, `fd_readdir` and `path_filestat_get`
