### PR TITLE
deps: updates wazero to 1.0.1

### DIFF
--- a/pi-zero-ssr/handler/go.mod
+++ b/pi-zero-ssr/handler/go.mod
@@ -1,5 +1,5 @@
 module ssr-handler
 
-go 1.17
+go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4
+require github.com/tetratelabs/wazero v1.0.1

--- a/pi-zero-ssr/handler/go.sum
+++ b/pi-zero-ssr/handler/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0) which begins our compatibility promise.

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.